### PR TITLE
`subcommands` to `sub`

### DIFF
--- a/commands/shell/index.js
+++ b/commands/shell/index.js
@@ -8,7 +8,7 @@ exports.yargs = {
 
         const { loadableModules, loadableCommands } = await extract()
 
-        const { subcommands } = require('@pown/script/commands/script/subcommands')
+        const { subcommands } = require('@pown/script/commands/script/sub')
 
         const executeOptions = {
             loadableModules: loadableModules,


### PR DESCRIPTION
`subcommands` folder doesn't exist in the script folder. But `sub` does exist and shell works perfectly after changing this